### PR TITLE
Add support for Scala 2.11, drop support for 2.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,17 +2,17 @@ organization := "io.argonaut"
 
 name := "argonaut-unfiltered"
 
-scalaVersion := "2.10.1"
+scalaVersion := "2.11.0"
 
-crossScalaVersions := Seq("2.9.2", "2.9.3", "2.10.1")
+crossScalaVersions := Seq("2.10.4", "2.11.0")
 
 releaseSettings
 
 libraryDependencies ++= Seq(
-  "io.argonaut" %% "argonaut" % "6.0",
-  "net.databinder" %% "unfiltered" % "0.6.8",
-  "net.databinder" %% "unfiltered-filter" % "0.6.8" % "test",
-  "net.databinder" %% "unfiltered-jetty" % "0.6.8" % "test"
+  "io.argonaut" %% "argonaut" % "6.0.4",
+  "net.databinder" %% "unfiltered" % "0.7.1",
+  "net.databinder" %% "unfiltered-filter" % "0.7.1" % "test",
+  "net.databinder" %% "unfiltered-jetty" % "0.7.1" % "test"
 )
 
 resolvers ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.13.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin(("com.typesafe.sbt" % "sbt-pgp" % "0.7").cross(CrossVersion.full))
+addSbtPlugin(("com.typesafe.sbt" % "sbt-pgp" % "0.8.3").cross(CrossVersion.full))
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")


### PR DESCRIPTION
I'm not quite sure if sbt needs to be bumped, but I thought it couldn't hurt. (Famous last words.)

Drops support for 2.9 because the bumped unfiltered dependencies aren't published for 2.9.x. I'm guessing it should be OK since the argonaut-unfiltered version was already bumped to 6.1-SNAPSHOT.
